### PR TITLE
Generate clap UT to detect config inconsistencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-settings-derive"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Manage CLI settings with configuration file(s) and command line parsing, using serde and clap"
 documentation = "https://docs.rs/cli-settings-derive"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,11 @@ impl<'a> SettingStruct<'a> {
             .iter()
             .map(|k| self.attrs.get(*k).unwrap_or(&empty))
             .collect::<Vec<_>>();
-        let vis = &self.s.vis;
+        let vis = if prefix.is_empty() {
+            self.s.vis.to_token_stream()
+        } else {
+            empty.clone()
+        };
         let struct_token = &self.s.struct_token;
         let name = format!("{}{}", prefix, self.s.ident);
         let ident = syn::Ident::new(&name, self.s.ident.span());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,24 @@ impl<'a> SettingStruct<'a> {
             }
         }
     }
+
+    /// Output parse_cli_args() function
+    fn output_clap_test(&self) -> proc_macro2::TokenStream {
+        let name = format!("Clap{}", self.s.ident);
+        let ident = syn::Ident::new(&name, self.s.ident.span());
+        quote! {
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn verify_cli() {
+                    use clap::CommandFactory;
+                    #ident ::command().debug_assert()
+                }
+            }
+        }
+    }
 }
 
 /// Macro to use on the Command Line Interface settings struct
@@ -485,6 +503,7 @@ pub fn cli_settings(
     let clap_struct = ss.output_clap_struct();
     let clap_struct_update = ss.output_clap_struct_update();
     let parse_cli_args = ss.output_parse_cli_args();
+    let clap_test = ss.output_clap_test();
 
     quote! {
         #main_struct
@@ -505,6 +524,8 @@ pub fn cli_settings(
             #clap_struct_update
 
             #parse_cli_args
+
+            #clap_test
         }
     }
     .into()

--- a/tests/expand.rs
+++ b/tests/expand.rs
@@ -2,6 +2,8 @@
 
 #[test]
 pub fn pass() {
-    // generate with test code
-    macrotest::expand_args("tests/expand/*.rs", &["--tests"]);
+    // generate with test code locally to see #[tests]
+    // (not activated by default as the output contains some local context)
+    //macrotest::expand_args("tests/expand/*.rs", &["--tests"]);
+    macrotest::expand("tests/expand/*.rs");
 }

--- a/tests/expand.rs
+++ b/tests/expand.rs
@@ -2,5 +2,6 @@
 
 #[test]
 pub fn pass() {
-    macrotest::expand("tests/expand/*.rs");
+    // generate with test code
+    macrotest::expand_args("tests/expand/*.rs", &["--tests"]);
 }

--- a/tests/expand/01-example.expanded.rs
+++ b/tests/expand/01-example.expanded.rs
@@ -127,4 +127,38 @@ mod _cli_settings_derive {
         cli_args.update(cfg);
         Ok(())
     }
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        extern crate test;
+        #[cfg(test)]
+        #[rustc_test_marker = "_cli_settings_derive::tests::verify_cli"]
+        pub const verify_cli: test::TestDescAndFn = test::TestDescAndFn {
+            desc: test::TestDesc {
+                name: test::StaticTestName("_cli_settings_derive::tests::verify_cli"),
+                ignore: false,
+                ignore_message: ::core::option::Option::None,
+                source_file: "/data/develop/github/cli-settings-derive/tests/expand/01-example.rs",
+                start_line: 7usize,
+                start_col: 1usize,
+                end_line: 7usize,
+                end_col: 16usize,
+                compile_fail: false,
+                no_run: false,
+                should_panic: test::ShouldPanic::No,
+                test_type: test::TestType::Unknown,
+            },
+            testfn: test::StaticTestFn(|| test::assert_test_result(verify_cli())),
+        };
+        fn verify_cli() {
+            use clap::CommandFactory;
+            ClapSettings::command().debug_assert()
+        }
+    }
+}
+#[rustc_main]
+#[no_coverage]
+pub fn main() -> () {
+    extern crate test;
+    test::test_main_static(&[&verify_cli])
 }

--- a/tests/expand/01-example.expanded.rs
+++ b/tests/expand/01-example.expanded.rs
@@ -43,7 +43,7 @@ mod _cli_settings_derive {
     use clap::Parser;
     use super::*;
     #[serde_with::serde_as]
-    pub struct FileSettings {
+    struct FileSettings {
         pub alpha: Option<u32>,
         pub gamma: Option<u64>,
     }
@@ -97,7 +97,7 @@ mod _cli_settings_derive {
     ///
     /// Application long description (visible with --help)
     #[command(version)]
-    pub struct ClapSettings {
+    struct ClapSettings {
         /// alpha setting explanation
         #[arg(long)]
         pub alpha: Option<u32>,

--- a/tests/expand/01-example.expanded.rs
+++ b/tests/expand/01-example.expanded.rs
@@ -127,38 +127,4 @@ mod _cli_settings_derive {
         cli_args.update(cfg);
         Ok(())
     }
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        extern crate test;
-        #[cfg(test)]
-        #[rustc_test_marker = "_cli_settings_derive::tests::verify_cli"]
-        pub const verify_cli: test::TestDescAndFn = test::TestDescAndFn {
-            desc: test::TestDesc {
-                name: test::StaticTestName("_cli_settings_derive::tests::verify_cli"),
-                ignore: false,
-                ignore_message: ::core::option::Option::None,
-                source_file: "/data/develop/github/cli-settings-derive/tests/expand/01-example.rs",
-                start_line: 7usize,
-                start_col: 1usize,
-                end_line: 7usize,
-                end_col: 16usize,
-                compile_fail: false,
-                no_run: false,
-                should_panic: test::ShouldPanic::No,
-                test_type: test::TestType::Unknown,
-            },
-            testfn: test::StaticTestFn(|| test::assert_test_result(verify_cli())),
-        };
-        fn verify_cli() {
-            use clap::CommandFactory;
-            ClapSettings::command().debug_assert()
-        }
-    }
-}
-#[rustc_main]
-#[no_coverage]
-pub fn main() -> () {
-    extern crate test;
-    test::test_main_static(&[&verify_cli])
 }


### PR DESCRIPTION
Clap is able to detect inconsistencies via a unit test.
The change generates a unit test to run clap sanity check.